### PR TITLE
feat: add workflow for checking compatibility with postgres and postgis (MAPCO-6391)

### DIFF
--- a/.github/workflows/postgis-check-command.yml
+++ b/.github/workflows/postgis-check-command.yml
@@ -22,6 +22,10 @@ on:
 
 env:
   DB_HOST: localhost
+  DB_PORT: 5432
+  DB_NAME: postgres
+  DB_USERNAME: postgres
+  DB_PASSWORD: 1234
   DEFAULT_VERSIONS: 12-2.5,13-3.3,14-3.3,14-3.5,16-3.5,17-3.5
   DEFAULT_NODE_VERSIONS: 20.x
 
@@ -104,9 +108,9 @@ jobs:
       postgres:
         image: postgis/postgis:${{matrix.postgres}}
         env:
-          POSTGRES_PASSWORD: 1234
-          POSTGRES_USER: postgres
-          POSTGRES_DB: postgres
+          POSTGRES_DB: ${{ env.DB_NAME }}
+          POSTGRES_USER: ${{ env.DB_USERNAME }}
+          POSTGRES_PASSWORD: ${{ env.DB_PASSWORD }}
         ports:
           - 5432:5432
         # Set health checks to wait until postgres has started

--- a/.github/workflows/postgis-check-command.yml
+++ b/.github/workflows/postgis-check-command.yml
@@ -1,20 +1,24 @@
 name: postgis-check
 
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
       issue-number:
         description: 'The issue-number of the slash command'
+        type: string
         required: true
       comment-creation-date:
         description: 'The slash command creation date passed from the slash-command workflow'
+        type: string
         required: true
       versions:
         description: 'Wanted postgis docker versions to check'
+        type: string
         default: 12-2.5,13-3.3,14-3.3,14-3.5,16-3.5,17-3.5
         required: false
       node-versions:
         description: 'Node.js versions to check'
+        type: string
         default: 20.x
         required: false
 

--- a/.github/workflows/postgis-check-command.yml
+++ b/.github/workflows/postgis-check-command.yml
@@ -13,10 +13,10 @@ on:
         description: 'Wanted postgis docker versions to check'
         default: 12-2.5,13-3.3,14-3.3,14-3.5,16-3.5,17-3.5
         required: false
-      node-versions:  
-        description: 'Node.js versions to check'  
-        default: 20.x  
-        required: false                                   
+      node-versions:
+        description: 'Node.js versions to check'
+        default: 20.x
+        required: false
 
 env:
   DB_HOST: localhost

--- a/.github/workflows/postgis-check-command.yml
+++ b/.github/workflows/postgis-check-command.yml
@@ -14,40 +14,66 @@ on:
       versions:
         description: 'Wanted postgis docker versions to check'
         type: string
-        default: 12-2.5,13-3.3,14-3.3,14-3.5,16-3.5,17-3.5
         required: false
       node-versions:
         description: 'Node.js versions to check'
         type: string
-        default: 20.x
         required: false
 
 env:
   DB_HOST: localhost
+  DEFAULT_VERSIONS: 12-2.5,13-3.3,14-3.3,14-3.5,16-3.5,17-3.5
+  DEFAULT_NODE_VERSIONS: 20.x
 
 jobs:
+  set_version_inputs_if_empty:
+    name: Sets input to default if empty
+    runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.set_version_inputs_if_empty.outputs.VERSIONS }}
+      node_versions: ${{ steps.set_version_inputs_if_empty.outputs.NODE_VERSIONS }}
+    steps:
+      - id: set_version_inputs_if_empty
+        run: |
+          if [ -z "${{inputs.versions}}" ]; then
+            versions=${{env.DEFAULT_VERSIONS}}
+          else
+            versions=${{ inputs.versions }}
+          fi
+
+          if [ -z "${{inputs.node-versions}}" ]; then
+            node_versions=${{env.DEFAULT_VERSIONS}}
+          else
+            node_versions=${{ inputs.node-versions }}
+          fi
+          
+          echo "VERSIONS=$versions" >> $GITHUB_OUTPUT
+          echo "NODE_VERSIONS=$node_versions" >> $GITHUB_OUTPUT
+
   # Convert versions variable from comma delimited string to JSON
   versions_to_json:
     name: Convert versions input to JSON
+    needs: [set_version_inputs_if_empty]
     runs-on: ubuntu-latest
     outputs:
       versions: ${{ steps.convert-to-json.outputs.VERSIONS }}
     steps:
       - id: convert-to-json
         run: |
-          versions=$(echo ${{ inputs.versions }} | jq -R -c 'split(",")')
+          versions=$(echo ${{ needs.set_version_inputs_if_empty.outputs.versions }} | jq -R -c 'split(",")')
           echo "VERSIONS=$versions" >> $GITHUB_OUTPUT
   
   # Convert node-versions variable from comma-delimited string to JSON  
   node_versions_to_json:
     name: Convert node-versions input to JSON
+    needs: [set_version_inputs_if_empty]
     runs-on: ubuntu-latest
     outputs:
       node_versions: ${{ steps.convert-to-json.outputs.NODE_VERSIONS }}
     steps:
       - id: convert-to-json
         run: |
-          versions=$(echo ${{ inputs.node-versions }} | jq -R -c 'split(",")')
+          versions=$(echo ${{ needs.set_version_inputs_if_empty.outputs.node_versions }} | jq -R -c 'split(",")')
           echo "NODE_VERSIONS=$versions" >> $GITHUB_OUTPUT
   
   # Create a PR comment for the workflow's results

--- a/.github/workflows/postgis-check-command.yml
+++ b/.github/workflows/postgis-check-command.yml
@@ -42,7 +42,7 @@ jobs:
           fi
 
           if [ -z "${{inputs.node-versions}}" ]; then
-            node_versions=${{env.DEFAULT_VERSIONS}}
+            node_versions=${{env.DEFAULT_NODE_VERSIONS}}
           else
             node_versions=${{ inputs.node-versions }}
           fi

--- a/.github/workflows/slash-command.yaml
+++ b/.github/workflows/slash-command.yaml
@@ -1,8 +1,7 @@
 name: Slash Command Dispatch
 
 on:
-  issue_comment:
-    types: [created]
+  workflow_call:
 
 jobs:
   slashCommandDispatch:


### PR DESCRIPTION
This PR adds two workflows in order to allow running a repositories tests against different versions of `postgis` and `node` via [slash-command](https://github.com/peter-evans/slash-command-dispatch) to check compatability.

A fix for the reverted PR - #33 #34 

Some issues iv'e run into during the creation of the workflows:
* Cannot dynamically collect the output of a matrix - https://github.com/orgs/community/discussions/17245
* When referencing the workflows from other repositories and passing empty input it is passed as an empty string (had to make some workaround) - https://github.com/actions/runner/issues/2907 https://github.com/actions/runner/issues/924