### PR TITLE
feat!: update pull_request.yaml openapi and eslint

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -54,20 +54,29 @@ jobs:
         run: npm ci
 
       - name: Run linters
-        uses: wearerequired/lint-action@v1
-        with:
-          github_token: ${{ secrets.github_token }}
-          # Enable linters
-          eslint: true
-          prettier: true
-          eslint_extensions: ts
+        run: npm run lint
+        
+  openapi-lint:
+    name: Run openapi-lint
+    runs-on: ubuntu-latest
+    if: ${{ inputs.enableOpenApiCheck == true }}
 
-      - name: OpenAPI Lint Checks
-        if: ${{ inputs.enableOpenApiCheck == true }}
-        uses: nwestfall/openapi-action@v1.0.2
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v1
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ${{ inputs.openApiFilePath }}
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run linters
+        run: npm run lint
+      - name: OpenAPI Lint Checks
+        run: npx @redocly/cli lint --format=github-actions openapi3.yaml
 
   security:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -75,8 +75,9 @@ jobs:
 
       - name: Run linters
         run: npm run lint
+        
       - name: OpenAPI Lint Checks
-        run: npx @redocly/cli lint --format=github-actions openapi3.yaml
+        run: npx @redocly/cli lint --format=github-actions ${{ inputs.openApiFilePath }}
 
   security:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request includes significant changes to the `.github/workflows/pull_request.yaml` file, primarily focusing on updating the linter setup and adding a new OpenAPI linting job. The most important changes are:

Updates to linter setup:

* Replaced the `wearerequired/lint-action` GitHub Action with a direct `npm run lint` command for running linters.

Addition of OpenAPI linting job:

* Introduced a new job `openapi-lint` that runs on `ubuntu-latest` and includes steps for setting up Node.js, installing dependencies, and running OpenAPI lint checks using `npx @redocly/cli lint`.